### PR TITLE
February 3/2016NodeKit Fork ChangeLogOSX El Capitan 10.11.3Xcode…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,7 @@ build/Release
 # Dependency directory
 # Commenting this out is preferred by some people, see
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git-
-node_modules
+#node_modules
 Carthage/
 
 # Users Environment Variables

--- a/src/nodekit.xcodeproj/project.pbxproj
+++ b/src/nodekit.xcodeproj/project.pbxproj
@@ -272,7 +272,6 @@
 		E4DEA2E61C591B3F00B787AD /* NKC_Process.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4DEA2E21C591B3F00B787AD /* NKC_Process.swift */; };
 		E4DEA2E91C59453C00B787AD /* SamplePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4DEA2E71C59453C00B787AD /* SamplePlugin.swift */; };
 		E4DEA2EB1C59453C00B787AD /* SamplePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4DEA2E71C59453C00B787AD /* SamplePlugin.swift */; };
-		E4DEA2EE1C59454900B787AD /* SamplePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4DEA2EC1C59454900B787AD /* SamplePlugin.swift */; };
 		E4DEA2EF1C59454900B787AD /* SamplePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4DEA2EC1C59454900B787AD /* SamplePlugin.swift */; };
 		E4DEA2F11C5C195000B787AD /* NKJSContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48C5E5D1C3F203C006CEF53 /* NKJSContext.swift */; };
 		E4DEA2F21C5C195400B787AD /* NKJSCContextFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48C5F131C3F4031006CEF53 /* NKJSCContextFactory.swift */; };
@@ -289,6 +288,7 @@
 		E4F347701C5582F200F96B29 /* NKCDateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F3476E1C55824D00F96B29 /* NKCDateFormatter.swift */; };
 		E4F347711C5582F200F96B29 /* NKCDateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F3476E1C55824D00F96B29 /* NKCDateFormatter.swift */; };
 		E4F347721C5582F300F96B29 /* NKCDateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F3476E1C55824D00F96B29 /* NKCDateFormatter.swift */; };
+		F15D77FE1C6223B9009F591B /* SamplePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4DEA2EC1C59454900B787AD /* SamplePlugin.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -1076,6 +1076,7 @@
 				E4D8C2D11C416CAD00D07A0F /* NKUIWebViewDelegate.swift in Sources */,
 				E4D8C2D31C416DE000D07A0F /* NKWKWebViewDelegate.swift in Sources */,
 				E48C5F141C3F4031006CEF53 /* NKJSCContextFactory.swift in Sources */,
+				F15D77FE1C6223B9009F591B /* SamplePlugin.swift in Sources */,
 				E4A8393E1C47446C00514698 /* NKE_BootElectroRenderer.swift in Sources */,
 				E4A838E91C46F26000514698 /* NKE_BrowserWindow_IOS.swift in Sources */,
 				E4A838721C46B80200514698 /* NKEApp.swift in Sources */,
@@ -1135,7 +1136,6 @@
 				E4E35F9C1C52B65500D0F270 /* NKC_Logging.swift in Sources */,
 				E4C253D21C20A5FF001B3388 /* NKMainDesktop.swift in Sources */,
 				E4D8C2D91C418D4C00D07A0F /* NKWVContextFactory.swift in Sources */,
-				E4DEA2EE1C59454900B787AD /* SamplePlugin.swift in Sources */,
 				E4A83D2F1C4993B900514698 /* NKC_Crypto.swift in Sources */,
 				E4A8393B1C47446C00514698 /* NKE_BootElectroMain.swift in Sources */,
 				E4A8392F1C47418900514698 /* NKE_IpcRenderer.swift in Sources */,


### PR DESCRIPTION
Very interesting project.  After I cloned the repo I had to make a few small changes so I thought I would send them back.  It looks like swift is a moving target but so worth it.

/W

February 3/2016

NodeKit Fork ChangeLog

OSX El Capitan 10.11.3
Xcode 7.2(7C68)
Apple Swift version 2.1.1 (swiftlang-700.1.101.15 clang-700.1.81)


This was all provided as default by Apple using only the AppStore on a clean OS X VM.

Xcode configuration default change:

Preferences —> Locations —> Derived Data —> Custom —> Relative to Workspace —>  Products = NodeKitBuild/Products && Intermediates = NodeKitBuild/Intermediates

This is in line with the standards set by the WebKit project, the excepting being that they dump both products and intermediates into the same folder.  In this case, due to the IOS / OS X
versions it was necessary to split it up.

1.  /src/nodekit-sample/platform-ios/SamplePlugin.swift. 

— nodekit-Mac && nodekit-sample-iOS 
++ nodekit-iOS && nodekit-sample-iOS

2. ran npm install @ src/nodekit-sample/test

3. test/node_modules/serve-static/node_modules/send/index.js

Line 243 results in:
STARTING TEST APPLICATION
Syntax Error in /test/node_modules/serve-static/node_modules/send/index.js
Cannot declare a parameter named 'error' as it shadows the name of a strict mode function.
TypeError: undefined is not an object (evaluating 'compiledWrapper.apply')